### PR TITLE
Update of file existence validation

### DIFF
--- a/server.go
+++ b/server.go
@@ -128,8 +128,11 @@ func ensureCertsExist(certPaths ...string) error {
 }
 
 // fileExists returns whether or not the path provided exists via os.Stat.
-func fileExists(path string) bool {
-	_, err := os.Stat(path)
-
-	return err == nil
+func fileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	
+	return !info.IsDir()
 }


### PR DESCRIPTION
There is a small suggestion of how the `fileExists` can be improved. There is a "stat" syscall behind `os.Stat`, and according to the `https://man7.org/linux/man-pages/man2/stat.2.html` there are multiple different errors that can be returned by this syscall, for example, if you have a circular symlink there. If you would like to check for the file existence, you can be more specific with your validation to ensure that error is exactly `not exist` error and the path is not a dir. Please see my PR. There is a snippet I typically use for that purpose. 